### PR TITLE
Marcos dev

### DIFF
--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -414,7 +414,7 @@ Optional query parameters:
 }
 ```
 
-### 11. **Get product reviews**
+### 12. **Get product reviews**
 
 **GET** `/mercadolibre/products/reviews/{product_id}?client_id={client_id}`
 
@@ -455,7 +455,7 @@ Required query parameters:
 }
 ```
 
-### 11. **Get product reviews**
+### 13. **Compare sales between months**
 
 **GET** `/mercadolibre/compare-sales-data/{client_id}?year1={year1}&month1={month1}&year2={year2}&month2={month2}`
 

--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -454,3 +454,69 @@ Required query parameters:
     }
 }
 ```
+
+### 11. **Get product reviews**
+
+**GET** `/mercadolibre/compare-sales-data/{client_id}?year1={year1}&month1={month1}&year2={year2}&month2={month2}`
+
+Required query parameters:
+- `year1`: The first year for compare (e.g., `2024`).
+- `month1`: The first month to compare (e.g, `10`).
+- `year2`: The second year for compare (e.g., `2025`).
+- `month2`: The second month to compare (e.g, `11`).
+
+
+#### Response (Success)
+
+```json
+{
+    "status": "success",
+    "message": "Comparación de ventas obtenida con éxito.",
+    "data": {
+        "month1": {
+            "year": "2024",
+            "month": "10",
+            "total_sales": 50000,
+            "sold_products": [
+                {
+                    "order_id": 1,
+                    "order_date": "2024-10-01",
+                    "title": "Producto A",
+                    "quantity": 2,
+                    "price": 10000
+                },
+                {
+                    "order_id": 2,
+                    "order_date": "2024-10-02",
+                    "title": "Producto B",
+                    "quantity": 3,
+                    "price": 5000
+                }
+            ]
+        },
+        "month2": {
+            "year": "2025",
+            "month": "01",
+            "total_sales": 40000,
+            "sold_products": [
+                {
+                    "order_id": 3,
+                    "order_date": "2025-01-01",
+                    "title": "Producto C",
+                    "quantity": 1,
+                    "price": 20000
+                },
+                {
+                    "order_id": 4,
+                    "order_date": "2025-01-02",
+                    "title": "Producto D",
+                    "quantity": 2,
+                    "price": 10000
+                }
+            ]
+        },
+        "difference": -10000,
+        "percentage_change": -20.0
+    }
+}
+```

--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -520,3 +520,64 @@ Required query parameters:
     }
 }
 ```
+
+### 14. **Compare sales between years**
+
+**GET** `/mercadolibre/compare-annual-sales-data/{client_id}?year1={year1}year2={year2}`
+
+Required query parameters:
+- `year1`: The first year for compare (e.g., `2024`).
+- `year2`: The second year for compare (e.g., `2025`).
+
+#### Response (Success)
+
+```json
+{
+    "status": "success",
+    "message": "Comparación de ventas obtenida con éxito.",
+    "data": {
+        "year1": {
+            "year": "2024",
+            "total_sales": 922132,
+            "sold_products": [
+                {
+                    "order_id": 1000000001,
+                    "order_date": "2024-07-25T12:50:51.000-04:00",
+                    "title": "Producto Ficticio A",
+                    "quantity": 1,
+                    "price": 13690
+                },
+                {
+                    "order_id": 1000000002,
+                    "order_date": "2024-08-08T21:18:32.000-04:00",
+                    "title": "Producto Ficticio B",
+                    "quantity": 2,
+                    "price": 12623
+                }
+            ]
+        },
+        "year2": {
+            "year": "2025",
+            "total_sales": 90390,
+            "sold_products": [
+                {
+                    "order_id": 2000000001,
+                    "order_date": "2025-01-02T15:23:40.000-04:00",
+                    "title": "Producto Ficticio C",
+                    "quantity": 2,
+                    "price": 5390
+                },
+                {
+                    "order_id": 2000000002,
+                    "order_date": "2025-01-02T15:23:40.000-04:00",
+                    "title": "Producto Ficticio D",
+                    "quantity": 2,
+                    "price": 5390
+                }
+            ]
+        },
+        "difference": -831742,
+        "percentage_change": -90.1977157283339
+    }
+}
+```

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1156,4 +1156,154 @@ class MercadoLibreDocumentsController extends Controller
         ]);
     }
 
+    /**
+     * Compare sales data between two years.
+     */
+    public function compareAnnualSalesData($clientId)
+    {
+        // Get credentials by client_id
+        $credentials = MercadoLibreCredential::where('client_id', $clientId)->first();
+
+        // Check if credentials exist
+        if (!$credentials) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se encontraron credenciales válidas para el client_id proporcionado.',
+            ], 404);
+        }
+
+        // Check if token is expired
+        if ($credentials->isTokenExpired()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'El token ha expirado. Por favor, renueve su token.',
+            ], 401);
+        }
+
+        // Get user id from token
+        $response = Http::withToken($credentials->access_token)
+            ->get('https://api.mercadolibre.com/users/me');
+
+        if ($response->failed()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se pudo obtener el ID del usuario. Por favor, valide su token.',
+                'error' => $response->json(),
+            ], 500);
+        }
+
+        $userId = $response->json()['id'];
+
+        // Get query parameters for the two years to compare
+        $year1 = request()->query('year1');
+        $year2 = request()->query('year2');
+
+        // Validate query parameters
+        if (!$year1 || !$year2) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Los parámetros de consulta year1 y year2 son obligatorios.',
+            ], 400);
+        }
+
+        // Calculate date range for the two years
+        $dateFrom1 = "{$year1}-01-01T00:00:00.000-00:00";
+        $dateTo1 = "{$year1}-12-31T23:59:59.999-00:00";
+        $dateFrom2 = "{$year2}-01-01T00:00:00.000-00:00";
+        $dateTo2 = "{$year2}-12-31T23:59:59.999-00:00";
+
+        // Function to fetch paginated data
+        $fetchPaginatedData = function ($dateFrom, $dateTo) use ($credentials, $userId) {
+            $totalSales = 0;
+            $soldProducts = [];
+            $offset = 0;
+            $limit = 50; // Adjust limit as needed
+
+            do {
+                $response = Http::withToken($credentials->access_token)
+                    ->get("https://api.mercadolibre.com/orders/search", [
+                        'seller' => $userId,
+                        'order.status' => 'paid',
+                        'order.date_created.from' => $dateFrom,
+                        'order.date_created.to' => $dateTo,
+                        'offset' => $offset,
+                        'limit' => $limit,
+                    ]);
+
+                if ($response->failed()) {
+                    return [
+                        'error' => true,
+                        'response' => $response,
+                    ];
+                }
+
+                $orders = $response->json()['results'];
+                foreach ($orders as $order) {
+                    $totalSales += $order['total_amount'];
+                    foreach ($order['order_items'] as $item) {
+                        $soldProducts[] = [
+                            'order_id' => $order['id'],
+                            'order_date' => $order['date_created'],
+                            'title' => $item['item']['title'],
+                            'quantity' => $item['quantity'],
+                            'price' => $item['unit_price'],
+                        ];
+                    }
+                }
+
+                $offset += $limit;
+            } while (count($orders) === $limit);
+
+            return [
+                'error' => false,
+                'total_sales' => $totalSales,
+                'sold_products' => $soldProducts,
+            ];
+        };
+
+        // Fetch data for the first year
+        $data1 = $fetchPaginatedData($dateFrom1, $dateTo1);
+        if ($data1['error']) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Error al conectar con la API de MercadoLibre.',
+                'error' => $data1['response']->json(),
+            ], $data1['response']->status());
+        }
+
+        // Fetch data for the second year
+        $data2 = $fetchPaginatedData($dateFrom2, $dateTo2);
+        if ($data2['error']) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Error al conectar con la API de MercadoLibre.',
+                'error' => $data2['response']->json(),
+            ], $data2['response']->status());
+        }
+
+        // Determine increase or decrease
+        $difference = $data2['total_sales'] - $data1['total_sales'];
+        $percentageChange = $data1['total_sales'] > 0 ? ($difference / $data1['total_sales']) * 100 : 0;
+
+        // Return comparison data
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Comparación de ventas obtenida con éxito.',
+            'data' => [
+                'year1' => [
+                    'year' => $year1,
+                    'total_sales' => $data1['total_sales'],
+                    'sold_products' => $data1['sold_products'],
+                ],
+                'year2' => [
+                    'year' => $year2,
+                    'total_sales' => $data2['total_sales'],
+                    'sold_products' => $data2['sold_products'],
+                ],
+                'difference' => $difference,
+                'percentage_change' => $percentageChange,
+            ],
+        ]);
+    }
+
 }

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1019,4 +1019,141 @@ class MercadoLibreDocumentsController extends Controller
         ]);
     }
 
+    /**
+     *  Compare sales data between two months
+    */
+
+    public function compareSalesData($clientId)
+    {
+        // Get credentials by client_id
+        $credentials = MercadoLibreCredential::where('client_id', $clientId)->first();
+
+        // Check if credentials exist
+        if (!$credentials) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se encontraron credenciales válidas para el client_id proporcionado.',
+            ], 404);
+        }
+
+        // Check if token is expired
+        if ($credentials->isTokenExpired()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'El token ha expirado. Por favor, renueve su token.',
+            ], 401);
+        }
+
+        // Get user id from token
+        $response = Http::withToken($credentials->access_token)
+            ->get('https://api.mercadolibre.com/users/me');
+
+        if ($response->failed()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se pudo obtener el ID del usuario. Por favor, valide su token.',
+                'error' => $response->json(),
+            ], 500);
+        }
+
+        $userId = $response->json()['id'];
+
+        // Get query parameters for the two months to compare
+        $month1 = request()->query('month1');
+        $year1 = request()->query('year1');
+        $month2 = request()->query('month2');
+        $year2 = request()->query('year2');
+
+        // Validate query parameters
+        if (!$month1 || !$year1 || !$month2 || !$year2) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Los parámetros de consulta month1, year1, month2 y year2 son obligatorios.',
+            ], 400);
+        }
+
+        // Calculate date range for the two months
+        $dateFrom1 = "{$year1}-{$month1}-01T00:00:00.000-00:00";
+        $dateTo1 = date("Y-m-t\T23:59:59.999-00:00", strtotime($dateFrom1));
+        $dateFrom2 = "{$year2}-{$month2}-01T00:00:00.000-00:00";
+        $dateTo2 = date("Y-m-t\T23:59:59.999-00:00", strtotime($dateFrom2));
+
+        // API request to get sales for the two months
+        $response1 = Http::withToken($credentials->access_token)
+            ->get("https://api.mercadolibre.com/orders/search?seller={$userId}&order.status=paid&order.date_created.from={$dateFrom1}&order.date_created.to={$dateTo1}");
+
+        $response2 = Http::withToken($credentials->access_token)
+            ->get("https://api.mercadolibre.com/orders/search?seller={$userId}&order.status=paid&order.date_created.from={$dateFrom2}&order.date_created.to={$dateTo2}");
+
+        // Validate responses
+        if ($response1->failed() || $response2->failed()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Error al conectar con la API de MercadoLibre.',
+                'error' => $response1->failed() ? $response1->json() : $response2->json(),
+            ], $response1->failed() ? $response1->status() : $response2->status());
+        }
+
+        // Process sales data
+        $orders1 = $response1->json()['results'];
+        $orders2 = $response2->json()['results'];
+
+        $totalSales1 = 0;
+        $totalSales2 = 0;
+        $soldProducts1 = [];
+        $soldProducts2 = [];
+
+        foreach ($orders1 as $order) {
+            $totalSales1 += $order['total_amount'];
+            foreach ($order['order_items'] as $item) {
+                $soldProducts1[] = [
+                    'order_id' => $order['id'],
+                    'order_date' => $order['date_created'],
+                    'title' => $item['item']['title'],
+                    'quantity' => $item['quantity'],
+                    'price' => $item['unit_price'],
+                ];
+            }
+        }
+
+        foreach ($orders2 as $order) {
+            $totalSales2 += $order['total_amount'];
+            foreach ($order['order_items'] as $item) {
+                $soldProducts2[] = [
+                    'order_id' => $order['id'],
+                    'order_date' => $order['date_created'],
+                    'title' => $item['item']['title'],
+                    'quantity' => $item['quantity'],
+                    'price' => $item['unit_price'],
+                ];
+            }
+        }
+
+        // Determine increase or decrease
+        $difference = $totalSales2 - $totalSales1;
+        $percentageChange = $totalSales1 > 0 ? ($difference / $totalSales1) * 100 : 0;
+
+        // Return comparison data
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Comparación de ventas obtenida con éxito.',
+            'data' => [
+                'month1' => [
+                    'year' => $year1,
+                    'month' => $month1,
+                    'total_sales' => $totalSales1,
+                    'sold_products' => $soldProducts1,
+                ],
+                'month2' => [
+                    'year' => $year2,
+                    'month' => $month2,
+                    'total_sales' => $totalSales2,
+                    'sold_products' => $soldProducts2,
+                ],
+                'difference' => $difference,
+                'percentage_change' => $percentageChange,
+            ],
+        ]);
+    }
+
 }

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1129,9 +1129,24 @@ class MercadoLibreDocumentsController extends Controller
             }
         }
 
+        // Ensure month1 is the older month and month2 is the newer month
+        $olderMonthSales = $totalSales1;
+        $newerMonthSales = $totalSales2;
+        if (strtotime("{$year1}-{$month1}-01") > strtotime("{$year2}-{$month2}-01")) {
+            $olderMonthSales = $totalSales2;
+            $newerMonthSales = $totalSales1;
+        }
+
         // Determine increase or decrease
-        $difference = $totalSales2 - $totalSales1;
-        $percentageChange = $totalSales1 > 0 ? ($difference / $totalSales1) * 100 : 0;
+        $difference = $newerMonthSales - $olderMonthSales;
+        if ($olderMonthSales > 0) {
+            $percentageChange = ($difference / $olderMonthSales) * 100;
+        } elseif ($newerMonthSales > 0) {
+            $percentageChange = 100;
+        } else {
+            $percentageChange = 0;
+        }
+        $percentageChange = round($percentageChange, 2);
 
         // Return comparison data
         return response()->json([

--- a/multistock-backend/routes/api.php
+++ b/multistock-backend/routes/api.php
@@ -135,5 +135,8 @@ Route::get('/mercadolibre/summary/{client_id}', [MercadoLibreDocumentsController
 // Compare sales data between two months
 Route::get('/mercadolibre/compare-sales-data/{client_id}', [MercadoLibreDocumentsController::class, 'compareSalesData']);
 
+// Compare sales data between two years
+Route::get('/mercadolibre/compare-annual-sales-data/{client_id}', [MercadoLibreDocumentsController::class, 'compareAnnualSalesData']);
+
 // Info route
 Route::get('/info', [InfoController::class, 'getInfo']);

--- a/multistock-backend/routes/api.php
+++ b/multistock-backend/routes/api.php
@@ -132,5 +132,8 @@ Route::get('/mercadolibre/top-payment-methods/{client_id}', [MercadoLibreDocumen
 // Get summary
 Route::get('/mercadolibre/summary/{client_id}', [MercadoLibreDocumentsController::class, 'summary']);
 
+// Compare sales data between two months
+Route::get('/mercadolibre/compare-sales-data/{client_id}', [MercadoLibreDocumentsController::class, 'compareSalesData']);
+
 // Info route
 Route::get('/info', [InfoController::class, 'getInfo']);


### PR DESCRIPTION
This pull request introduces new functionality for comparing sales data between two months and two years in the MercadoLibre integration. The changes include updates to the documentation, the addition of new endpoints, and the implementation of the corresponding controller methods.

### Documentation Updates:
* [`Docs/MercadoLibreDocumentsDocs.md`](diffhunk://#diff-85e6c31490d4052952364e19e4ec2a2405b4f062729f32b3fe066449469d70ddR457-R583): Added new sections for "Compare sales between months" and "Compare sales between years" with required query parameters and example responses.

### New Endpoints:
* [`multistock-backend/routes/api.php`](diffhunk://#diff-8d5c1812d7656ac9c94a0dcbfe3fb5e95c9695ed179021552dee6cd4e71dd671R135-R140): Added routes for comparing sales data between two months and two years.

### Controller Methods:
* [`multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php`](diffhunk://#diff-0adf5421da6d525938c66ad7224adc04115dfae6646ee6e7363da295dba1bc9dR1022-R1323): Implemented `compareSalesData` and `compareAnnualSalesData` methods to handle the new comparison functionality.