### PR TITLE
Daily Merge 29-01-25

### DIFF
--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -581,3 +581,54 @@ Required query parameters:
     }
 }
 ```
+
+### 15. **Get sales data by date range**
+
+**GET** `/mercadolibre/sales-by-date-range/{client_id}?start_date={start_date}end_date={end_date}`
+
+Required query parameters:
+- `start_date`: The first date range for compare (e.g., `2025-01-01`).
+- `end_date`: The last date range for compare (e.g., `2025-01-31`).
+
+#### Response (Success)
+
+```json
+{
+    "status": "success",
+    "message": "Ventas obtenidas con éxito.",
+    "data": {
+        "2025-01-02": [
+            {
+                "order_id": 2000010344476138,
+                "order_date": "2025-01-02T15:23:40.000-04:00",
+                "total_amount": 10780,
+                "payment_method": "account_money",
+                "products": [
+                    {
+                        "title": "Cuadro Mujer Lady Genny C-413 Maxi Cotton Spandex",
+                        "quantity": 2,
+                        "price": 5390,
+                        "category_id": "MLC6428",
+                        "category": "Calzones"
+                    }
+                ]
+            },
+            {
+                "order_id": 2000010344463476,
+                "order_date": "2025-01-02T15:23:40.000-04:00",
+                "total_amount": 10780,
+                "payment_method": "account_money",
+                "products": [
+                    {
+                        "title": "Cuadro Mujer Lady Genny C-413 Maxi Cotton Spandex",
+                        "quantity": 2,
+                        "price": 5390,
+                        "category_id": "MLC6428",
+                        "category": "Calzones"
+                    }
+                ]
+            }
+        ]
+    }
+}
+```

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1361,11 +1361,11 @@ class MercadoLibreDocumentsController extends Controller
         $userId = $response->json()['id'];
 
         // Get query parameters for date range
-        $dateFrom = $request->query('fecha_inicial');
-        $dateTo = $request->query('fecha_final');
+        $startDate = $request->query('start_date');
+        $endDate = $request->query('end_date');
 
         // Validate date range
-        if (!$dateFrom || !$dateTo) {
+        if (!$startDate || !$endDate) {
             return response()->json([
                 'status' => 'error',
                 'message' => 'Las fechas inicial y final son requeridas.',
@@ -1377,8 +1377,8 @@ class MercadoLibreDocumentsController extends Controller
             ->get("https://api.mercadolibre.com/orders/search", [
                 'seller' => $userId,
                 'order.status' => 'paid',
-                'order.date_created.from' => "{$dateFrom}T00:00:00.000-00:00",
-                'order.date_created.to' => "{$dateTo}T23:59:59.999-00:00"
+                'order.date_created.from' => "{$startDate}T00:00:00.000-00:00",
+                'order.date_created.to' => "{$endDate}T23:59:59.999-00:00"
             ]);
 
         // Validate response

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1299,6 +1299,7 @@ class MercadoLibreDocumentsController extends Controller
         // Determine increase or decrease
         $difference = $data2['total_sales'] - $data1['total_sales'];
         $percentageChange = $data1['total_sales'] > 0 ? ($difference / $data1['total_sales']) * 100 : 0;
+        $percentageChange = round($percentageChange, 2); // Ensure two decimal places
 
         // Return comparison data
         return response()->json([

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1404,6 +1404,7 @@ class MercadoLibreDocumentsController extends Controller
                 'order_id' => $order['id'],
                 'order_date' => $order['date_created'],
                 'total_amount' => $order['total_amount'],
+                'payment_method' => $order['payments'][0]['payment_type'] ?? 'unknown',
                 'products' => [],
             ];
 

--- a/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibreDocumentsController.php
@@ -1321,4 +1321,121 @@ class MercadoLibreDocumentsController extends Controller
         ]);
     }
 
+    /**
+     * Get sales by date range from MercadoLibre API using client_id.
+    */
+
+    public function getSalesByDateRange(Request $request, $clientId)
+    {
+        // Get credentials by client_id
+        $credentials = MercadoLibreCredential::where('client_id', $clientId)->first();
+
+        // Check if credentials exist
+        if (!$credentials) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se encontraron credenciales válidas para el client_id proporcionado.',
+            ], 404);
+        }
+
+        // Check if token is expired
+        if ($credentials->isTokenExpired()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'El token ha expirado. Por favor, renueve su token.',
+            ], 401);
+        }
+
+        // Get user id from token
+        $response = Http::withToken($credentials->access_token)
+            ->get('https://api.mercadolibre.com/users/me');
+
+        if ($response->failed()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se pudo obtener el ID del usuario. Por favor, valide su token.',
+                'error' => $response->json(),
+            ], 500);
+        }
+
+        $userId = $response->json()['id'];
+
+        // Get query parameters for date range
+        $dateFrom = $request->query('fecha_inicial');
+        $dateTo = $request->query('fecha_final');
+
+        // Validate date range
+        if (!$dateFrom || !$dateTo) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Las fechas inicial y final son requeridas.',
+            ], 400);
+        }
+
+        // API request to get sales within the specified date range
+        $response = Http::withToken($credentials->access_token)
+            ->get("https://api.mercadolibre.com/orders/search", [
+                'seller' => $userId,
+                'order.status' => 'paid',
+                'order.date_created.from' => "{$dateFrom}T00:00:00.000-00:00",
+                'order.date_created.to' => "{$dateTo}T23:59:59.999-00:00"
+            ]);
+
+        // Validate response
+        if ($response->failed()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Error al conectar con la API de MercadoLibre.',
+                'error' => $response->json(),
+            ], $response->status());
+        }
+
+        // Process sales data
+        $orders = $response->json()['results'];
+        $salesData = [];
+
+        foreach ($orders as $order) {
+            $orderDate = date('Y-m-d', strtotime($order['date_created']));
+            if (!isset($salesData[$orderDate])) {
+                $salesData[$orderDate] = [];
+            }
+
+            $orderData = [
+                'order_id' => $order['id'],
+                'order_date' => $order['date_created'],
+                'total_amount' => $order['total_amount'],
+                'products' => [],
+            ];
+
+            // Extract sold products (titles, quantities, categories, prices)
+            foreach ($order['order_items'] as $item) {
+                $productData = [
+                    'title' => $item['item']['title'],
+                    'quantity' => $item['quantity'],
+                    'price' => $item['unit_price'],
+                    'category_id' => $item['item']['category_id'],
+                ];
+
+                // Get category details
+                $categoryResponse = Http::withToken($credentials->access_token)
+                    ->get("https://api.mercadolibre.com/categories/{$item['item']['category_id']}");
+
+                if (!$categoryResponse->failed()) {
+                    $productData['category'] = $categoryResponse->json()['name'];
+                }
+
+                $orderData['products'][] = $productData;
+            }
+
+            $salesData[$orderDate][] = $orderData;
+        }
+
+        // Return sales data grouped by day
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Ventas obtenidas con éxito.',
+            'data' => $salesData,
+        ]);
+    }
+
 }

--- a/multistock-backend/routes/api.php
+++ b/multistock-backend/routes/api.php
@@ -138,5 +138,8 @@ Route::get('/mercadolibre/compare-sales-data/{client_id}', [MercadoLibreDocument
 // Compare sales data between two years
 Route::get('/mercadolibre/compare-annual-sales-data/{client_id}', [MercadoLibreDocumentsController::class, 'compareAnnualSalesData']);
 
+// Get sales by date range
+Route::get('/mercadolibre/sales-by-date-range/{client_id}', [MercadoLibreDocumentsController::class, 'getSalesByDateRange']);
+
 // Info route
 Route::get('/info', [InfoController::class, 'getInfo']);


### PR DESCRIPTION
This pull request introduces a new feature to get sales data by date range from the MercadoLibre API and includes documentation updates, controller methods, and route additions to support this feature. The most important changes are summarized below:

### New Feature: Get Sales Data by Date Range

* **Documentation Update**:
  - Added a new section in `Docs/MercadoLibreDocumentsDocs.md` to document the endpoint for fetching sales data by date range, including required query parameters and a sample success response.

* **Controller Method**:
  - Introduced a new method `getSalesByDateRange` in `MercadoLibreDocumentsController.php` to handle the logic for fetching sales data from the MercadoLibre API based on the provided date range and client ID. This method includes validation for credentials and date range, API requests to MercadoLibre, and processing of the sales data.

* **Route Addition**:
  - Added a new route in `multistock-backend/routes/api.php` to map the new endpoint `/mercadolibre/sales-by-date-range/{client_id}` to the `getSalesByDateRange` method in the controller.

### Code Improvement

* **Percentage Change Calculation**:
  - Updated the `compareAnnualSalesData` method in `MercadoLibreDocumentsController.php` to round the percentage change to two decimal places for better readability.