### PR TITLE
refactor issues and new doc 

### DIFF
--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -350,6 +350,11 @@ Optional query parameters:
 
 ### 9. **Get top payment methods**
 
+- `year`: The year for which to retrieve sales data (e.g., `2025`).
+- `month`: The month for which to retrieve sales data (e.g., `01`).
+
+> Note: If the `year` parameter is not provided, the system will default to the current year.
+
 **GET** `/mercadolibre/top-payment-methods/{client_id}`
 
 #### Response (Success)

--- a/Docs/MercadoLibreDocumentsDocs.md
+++ b/Docs/MercadoLibreDocumentsDocs.md
@@ -274,21 +274,76 @@ Optional query parameters:
 **GET** `/mercadolibre/order-statuses/{client_id}`
 
 - `year`: The year for which to retrieve sales data (e.g., `2025`).
+- `month`: The month for which to retrieve sales data (e.g., `01`).
 
 > Note: If the `year` parameter is not provided, the system will default to the current year.
-
-> Note 2: If the `year` parameter is set to 'alloftimes', the system will return data for all years of sales.
 
 
 #### Response (Success)
 ```json
 {
     "status": "success",
-    "message": "Estados de órdenes obtenidos con éxito.",
+    "message": "Estados de órdenes y productos relacionados obtenidos con éxito.",
     "data": {
-        "paid": 36,
-        "pending": 0,
-        "canceled": 0
+        "statuses": {
+            "paid": 9,
+            "pending": 0,
+            "canceled": 0
+        },
+        "products": [
+            {
+                "id": "MLC1234567890",
+                "title": "Producto Ejemplo A",
+                "category_id": "MLC1234",
+                "variation_id": 123456789012,
+                "seller_custom_field": null,
+                "global_price": null,
+                "net_weight": null,
+                "variation_attributes": [
+                    {
+                        "name": "Color",
+                        "id": "COLOR",
+                        "value_id": "12345",
+                        "value_name": "Rojo"
+                    },
+                    {
+                        "name": "Talla",
+                        "id": "SIZE",
+                        "value_id": "67890",
+                        "value_name": "M"
+                    }
+                ],
+                "warranty": "Garantía del vendedor: 6 meses",
+                "condition": "new",
+                "seller_sku": "A-123-ROJ-M"
+            },
+            {
+                "id": "MLC0987654321",
+                "title": "Producto Ejemplo B",
+                "category_id": "MLC5678",
+                "variation_id": 987654321098,
+                "seller_custom_field": null,
+                "global_price": null,
+                "net_weight": null,
+                "variation_attributes": [
+                    {
+                        "name": "Color",
+                        "id": "COLOR",
+                        "value_id": "54321",
+                        "value_name": "Azul"
+                    },
+                    {
+                        "name": "Talla",
+                        "id": "SIZE",
+                        "value_id": "09876",
+                        "value_name": "L"
+                    }
+                ],
+                "warranty": "Garantía del vendedor: 3 meses",
+                "condition": "new",
+                "seller_sku": "B-987-AZU-L"
+            }
+        ]
     }
 }
 ```
@@ -296,8 +351,6 @@ Optional query parameters:
 ### 9. **Get top payment methods**
 
 **GET** `/mercadolibre/top-payment-methods/{client_id}`
-
-
 
 #### Response (Success)
 ```json

--- a/multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/getOrderStatusesController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/getOrderStatusesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\MercadoLibre\Reportes;
 use App\Models\MercadoLibreCredential;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class getOrderStatusesController
 {
@@ -12,7 +13,7 @@ class getOrderStatusesController
     /**
      * Get order statuses (paid, pending, canceled) from MercadoLibre API using client_id.
     */
-    public function getOrderStatuses($clientId)
+    public function getOrderStatuses(Request $request, $clientId)
     {
         // Get credentials by client_id
         $credentials = MercadoLibreCredential::where('client_id', $clientId)->first();
@@ -47,9 +48,13 @@ class getOrderStatusesController
 
         $userId = $response->json()['id'];
 
+        // Get month and year from query parameters or use current month and year
+        $month = $request->query('month', Carbon::now()->month);
+        $year = $request->query('year', Carbon::now()->year);
+
         // API request to get order statuses
         $response = Http::withToken($credentials->access_token)
-            ->get("https://api.mercadolibre.com/orders/search?seller={$userId}");
+            ->get("https://api.mercadolibre.com/orders/search?seller={$userId}&order.date_created.from={$year}-{$month}-01T00:00:00.000-00:00&order.date_created.to={$year}-{$month}-".Carbon::now()->daysInMonth."T23:59:59.999-00:00");
 
         // Validate response
         if ($response->failed()) {
@@ -60,25 +65,32 @@ class getOrderStatusesController
             ], $response->status());
         }
 
-        // Process order statuses
+        // Process order statuses and related products
         $orders = $response->json()['results'];
         $statuses = [
             'paid' => 0,
             'pending' => 0,
             'canceled' => 0,
         ];
+        $products = [];
 
         foreach ($orders as $order) {
             if (isset($statuses[$order['status']])) {
                 $statuses[$order['status']]++;
             }
+            foreach ($order['order_items'] as $item) {
+                $products[] = $item['item'];
+            }
         }
 
-        // Return order statuses data
+        // Return order statuses and related products data
         return response()->json([
             'status' => 'success',
-            'message' => 'Estados de órdenes obtenidos con éxito.',
-            'data' => $statuses,
+            'message' => 'Estados de órdenes y productos relacionados obtenidos con éxito.',
+            'data' => [
+                'statuses' => $statuses,
+                'products' => $products,
+            ],
         ]);
     }
     

--- a/multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/summaryController.php
+++ b/multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/summaryController.php
@@ -83,7 +83,7 @@ class summaryController
 
         // Get order statuses
         $orderStatusesController = new getOrderStatusesController();
-        $orderStatusesResponse = $orderStatusesController->getOrderStatuses($clientId);
+        $orderStatusesResponse = $orderStatusesController->getOrderStatuses(new Request(), $clientId);
         if ($orderStatusesResponse->getStatusCode() !== 200) {
             return $orderStatusesResponse;
         }


### PR DESCRIPTION
This pull request includes updates to the MercadoLibre order statuses feature, enhancing the functionality by adding new query parameters and improving the data returned in the response.

### Enhancements to MercadoLibre order statuses:

* Added `month` query parameter to the `GET /mercadolibre/order-statuses/{client_id}` endpoint to allow filtering sales data by month.
* Updated the `getOrderStatuses` method in `multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/getOrderStatusesController.php` to retrieve `month` and `year` from query parameters or default to the current month and year.
* Modified the response of the `getOrderStatuses` method to include related products along with order statuses.

### Codebase improvements:

* Added `Carbon` import in `multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/getOrderStatusesController.php` for date handling.
* Updated the `summary` method in `multistock-backend/app/Http/Controllers/MercadoLibre/Reportes/summaryController.php` to pass the `Request` object when calling `getOrderStatuses`.